### PR TITLE
ADBDEV-1626. Remove operator new, operator delete from local: directive in version…

### DIFF
--- a/src/library.ver
+++ b/src/library.ver
@@ -1,14 +1,5 @@
 VERS_1.0 {
     local:
-        _Znwm;                 # operator new(unsigned long);
-        _ZnwmRKSt9nothrow_t;   # operator new(unsigned long, std::nothrow_t const&);
-        _ZdlPv;                # operator delete(void*);
-        _ZdlPvRKSt9nothrow_t;  # operator delete(void*, std::nothrow_t const&);
-        _Znam;                 # operator new[](unsigned long);
-        _ZnamRKSt9nothrow_t;   # operator new[](unsigned long, std::nothrow_t const&);
-        _ZdaPv;                # operator delete[](void*);
-        _ZdaPvRKSt9nothrow_t;  # operator delete[](void*, std::nothrow_t const&);
-
         extern "C++" {
 #
 # Hide everything in std namespace (C++ STL symbols):


### PR DESCRIPTION
Remove declarations of various overrides of `operator new()` and `operator delete()` from the `local:` directive in version script file used by linker.

This resolves an issue with usage of incorrect `operator new()`, reproducible by e.g. MADlib `linalg` test.


